### PR TITLE
Racket: Change implementation of ALPHABET

### DIFF
--- a/racket/norvig.rkt
+++ b/racket/norvig.rkt
@@ -14,7 +14,7 @@
 (require racket/list)
 (require racket/cmdline)
 
-(define ALPHABET (in-list (string->list "abcdefghijklmnopqrstuvwxyz")))
+(define ALPHABET (map string (string->list "abcdefghijklmnopqrstuvwxyz")))
 
 ;; type HFrequency = [Hashof String Nat]
 ;; type LFrequency = [Listof [Cons String Nat]]
@@ -107,13 +107,13 @@
 
 ;; Splits -> [Listof String]
 (define (inserts ss)
-  (for*/list ([s (in-list ss)] [c ALPHABET])
-    (string-append (car s) (string c) (cdr s))))
+  (for*/list ([s (in-list ss)] [c (in-list ALPHABET)])
+    (string-append (car s) c (cdr s))))
 
 ;; Splits -> [Listof String]
 (define (replaces ss)
-  (for*/list ([s (in-list ss)] [rht (in-value (cdr s))] #:when (not (string=? rht "")) [c ALPHABET])
-    (string-append (car s) (string c) (substring rht 1))))
+  (for*/list ([s (in-list ss)] [rht (in-value (cdr s))] #:when (not (string=? rht "")) [c (in-list ALPHABET)])
+    (string-append (car s) c (substring rht 1))))
 
 ;; Splits -> [Listof String]
 (define (transposes ss)


### PR DESCRIPTION
Move `in-list` to bound sites and move `string` to binding site.

In my machine, this reduces the time of the tests from 17.7 seconds, to 16.2 seconds, and finally to 14.5 seconds.
